### PR TITLE
Support query of memory preset keys M1-M6

### DIFF
--- a/hm305.py
+++ b/hm305.py
@@ -39,6 +39,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--get-voltage-max", action="store_true", help="report possible max voltage"
     )
+    parser.add_argument(
+        "--get-memory", action="store_true", help="get MEMORY key settings"
+    )
     parser.add_argument("--info", action="store_true", help="get PSU info")
 
     def auto_int(x):
@@ -86,6 +89,14 @@ if __name__ == "__main__":
             logging.info(f"{hm.w} Watts")
         if args.get_voltage_max:
             logging.info(f"{hm.vmax} Volts")
+        if args.get_memory:
+            memory_values = hm.memory()
+            logging.info("Memory Key Presets:")
+            for key in memory_values:
+                logging.info(f"{key} : {memory_values[key]['Voltage']} Volts")
+                logging.info(f"{key} : {memory_values[key]['Current']} Current")
+                logging.info(f"{key} : {memory_values[key]['Time_span']} Time Span")
+                logging.info(f"{key} : {memory_values[key]['Enable']} Enable")
         if args.info:
             logging.info(
                 f"Info:\n"

--- a/hm305.py
+++ b/hm305.py
@@ -6,7 +6,7 @@ import logging
 
 from hm305 import HM305
 
-logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
 
 if __name__ == "__main__":
     import argparse
@@ -14,29 +14,37 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     serial_parser = parser.add_mutually_exclusive_group(required=True)
-    serial_parser.add_argument('--port', type=str, help='serial port')
+    serial_parser.add_argument("--port", type=str, help="serial port")
 
     volt_parser = parser.add_mutually_exclusive_group()
-    volt_parser.add_argument('--voltage', type=float, help='set voltage')
-    volt_parser.add_argument('--adj-voltage', metavar="X", type=float, help='adjust voltage by X')
+    volt_parser.add_argument("--voltage", type=float, help="set voltage")
+    volt_parser.add_argument(
+        "--adj-voltage", metavar="X", type=float, help="adjust voltage by X"
+    )
     current_parser = parser.add_mutually_exclusive_group()
-    current_parser.add_argument('--current', type=float, help='set current')
+    current_parser.add_argument("--current", type=float, help="set current")
 
     output_parser = parser.add_mutually_exclusive_group()
-    output_parser.add_argument('--on', action='store_true', help='switch output on')
-    output_parser.add_argument('--off', action='store_true', help='switch output off')
+    output_parser.add_argument("--on", action="store_true", help="switch output on")
+    output_parser.add_argument("--off", action="store_true", help="switch output off")
     beep_parser = parser.add_mutually_exclusive_group()
-    beep_parser.add_argument('--beep', action='store_true', help='enable beeping')
-    beep_parser.add_argument('--nobeep', action='store_true', help='disable beeping')
+    beep_parser.add_argument("--beep", action="store_true", help="enable beeping")
+    beep_parser.add_argument("--nobeep", action="store_true", help="disable beeping")
 
-    parser.add_argument('--debug', action='store_true', help='enable verbose logging')
-    parser.add_argument('--get', action='store_true', help='report output measurements')
-    parser.add_argument('--get-power', action='store_true', help='report output power in W')
-    parser.add_argument('--get-voltage-max', action='store_true', help='report possible max voltage')
-    parser.add_argument('--info', action='store_true', help='get PSU info')
+    parser.add_argument("--debug", action="store_true", help="enable verbose logging")
+    parser.add_argument("--get", action="store_true", help="report output measurements")
+    parser.add_argument(
+        "--get-power", action="store_true", help="report output power in W"
+    )
+    parser.add_argument(
+        "--get-voltage-max", action="store_true", help="report possible max voltage"
+    )
+    parser.add_argument("--info", action="store_true", help="get PSU info")
+
     def auto_int(x):
         return int(x, 0)
-    parser.add_argument('--raw', type=auto_int, help='get a raw address')
+
+    parser.add_argument("--raw", type=auto_int, help="get a raw address")
 
     args = parser.parse_args()
 
@@ -79,12 +87,14 @@ if __name__ == "__main__":
         if args.get_voltage_max:
             logging.info(f"{hm.vmax} Volts")
         if args.info:
-            logging.info(f"Info:\n"
-                         f"Model: {hm.model}\n"
-                         f"protect_state {hm.protect_state}\n"
-                         f"decimals: {hex(hm.decimals)}\n"
-                         f"class_details: {hex(hm.classdetail)}\n"
-                         f"Device: {hm.device}")
+            logging.info(
+                f"Info:\n"
+                f"Model: {hm.model}\n"
+                f"protect_state {hm.protect_state}\n"
+                f"decimals: {hex(hm.decimals)}\n"
+                f"class_details: {hex(hm.classdetail)}\n"
+                f"Device: {hm.device}"
+            )
         if args.raw:
             val = hm.modbus.get_by_addr(args.raw)
             logging.info(f"{args.raw: x}: {val} / {val: x}")

--- a/hm305.py
+++ b/hm305.py
@@ -90,13 +90,13 @@ if __name__ == "__main__":
         if args.get_voltage_max:
             logging.info(f"{hm.vmax} Volts")
         if args.get_memory:
-            memory_values = hm.memory()
+            memory_values = hm.memory
             logging.info("Memory Key Presets:")
             for key in memory_values:
-                logging.info(f"{key} : {memory_values[key]['Voltage']} Volts")
-                logging.info(f"{key} : {memory_values[key]['Current']} Current")
+                logging.info(f"{key} : {memory_values[key]['Volts']} Volts")
+                logging.info(f"{key} : {memory_values[key]['Amps']} Amps")
                 logging.info(f"{key} : {memory_values[key]['Time_span']} Time Span")
-                logging.info(f"{key} : {memory_values[key]['Enable']} Enable")
+                logging.info(f"{key} : {memory_values[key]['Enabled']} Enabled")
         if args.info:
             logging.info(
                 f"Info:\n"

--- a/hm305/__init__.py
+++ b/hm305/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from enum import IntEnum
+from enum import IntEnum, auto
 import serial
 
 from modbus import Modbus
@@ -39,48 +39,53 @@ class HM305:
         Voltage_Max = 0xC11E  # returns 3200 = 32.0 V
         Current_Min = 0xC120  # returns 21 on my HM310P = 0.021A?
         Current_Max = 0xC12E  # returns 10100 on my HM310p = 10.1A
-        # M1 - M6 Memory key registers
-        # Factory defaults :-
-        #    Voltage: (1, 3, 5, 7, 9,10) / 10 * (UH =  3200) => (320,960,1600,2240,2880,3200)
-        #    Current: (1, 3, 5, 7, 9,10) / 10 * (UL = 10100) => (1010,3030,5050,7070,9090,10100)
-        #    Seconds: 10,11,12,13,14,15
-        #    Enable:   1, 1, 1, 1, 1, 1
+
+    class PRESET(auto):
+        """
+        M1 - M6 Memory key registers
+        Factory defaults :-
+           Volts: (1, 3, 5, 7, 9,10) / 10 * (UH =  3200) => (320,960,1600,2240,2880,3200)
+           Amps: (1, 3, 5, 7, 9,10) / 10 * (UL = 10100) => (1010,3030,5050,7070,9090,10100)
+           Seconds: 10,11,12,13,14,15
+           Enabled:  1, 1, 1, 1, 1, 1
+        """
+
         Memory = {
             "M1": {
-                "Voltage": 0x1000,  # (R/W)
-                "Current": 0x1001,  # (R/W)
+                "Volts": 0x1000,  # (R/W)
+                "Amps": 0x1001,  # (R/W)
                 "Time_span": 0x1002,  # (R/W)
-                "Enable": 0x1003,  # (R/W)
+                "Enabled": 0x1003,  # (R/W)
             },
             "M2": {
-                "Voltage": 0x1010,  # (R/W)
-                "Current": 0x1011,  # (R/W)
+                "Volts": 0x1010,  # (R/W)
+                "Amps": 0x1011,  # (R/W)
                 "Time_span": 0x1012,  # (R/W)
-                "Enable": 0x1013,  # (R/W)
+                "Enabled": 0x1013,  # (R/W)
             },
             "M3": {
-                "Voltage": 0x1020,  # (R/W)
-                "Current": 0x1021,  # (R/W)
+                "Volts": 0x1020,  # (R/W)
+                "Amps": 0x1021,  # (R/W)
                 "Time_span": 0x1022,  # (R/W)
-                "Enable": 0x1023,  # (R/W)
+                "Enabled": 0x1023,  # (R/W)
             },
             "M4": {
-                "Voltage": 0x1030,  # (R/W)
-                "Current": 0x1031,  # (R/W)
+                "Volts": 0x1030,  # (R/W)
+                "Amps": 0x1031,  # (R/W)
                 "Time_span": 0x1032,  # (R/W)
-                "Enable": 0x1033,  # (R/W)
+                "Enabled": 0x1033,  # (R/W)
             },
             "M5": {
-                "Voltage": 0x1040,  # (R/W)
-                "Current": 0x1041,  # (R/W)
+                "Volts": 0x1040,  # (R/W)
+                "Amps": 0x1041,  # (R/W)
                 "Time_span": 0x1042,  # (R/W)
-                "Enable": 0x1043,  # (R/W)
+                "Enabled": 0x1043,  # (R/W)
             },
             "M6": {
-                "Voltage": 0x1050,  # (R/W)
-                "Current": 0x1051,  # (R/W)
+                "Volts": 0x1050,  # (R/W)
+                "Amps": 0x1051,  # (R/W)
                 "Time_span": 0x1052,  # (R/W)
-                "Enable": 0x1053,  # (R/W)
+                "Enabled": 0x1053,  # (R/W)
             },
         }
 
@@ -197,19 +202,19 @@ class HM305:
     @property
     def memory(self):
         """ Return a dict of dicts for each [preset memory keys][registers] """
-        memory_values = {}
-        for key in HM305.CMD.Memory:
-            memory_values[key]["Voltage"] = self._get_val(
-                HM305.CMD.Memory[key]["Voltage"]
+        memory_values = HM305.PRESET.Memory
+        for key in HM305.PRESET.Memory:
+            memory_values[key]["Volts"] = (
+                self._get_val(HM305.PRESET.Memory[key]["Volts"]) / 100.0
             )
-            memory_values[key]["Current"] = self._get_val(
-                HM305.CMD.Memory[key]["Current"]
+            memory_values[key]["Amps"] = (
+                self._get_val(HM305.PRESET.Memory[key]["Amps"]) / 1000.0
             )
             memory_values[key]["Time_span"] = self._get_val(
-                HM305.CMD.Memory[key]["Time_span"]
+                HM305.PRESET.Memory[key]["Time_span"]
             )
-            memory_values[key]["Enable"] = self._get_val(
-                HM305.CMD.Memory[key]["Enable"]
+            memory_values[key]["Enabled"] = self._get_val(
+                HM305.PRESET.Memory[key]["Enabled"]
             )
         return memory_values
 

--- a/hm305/__init__.py
+++ b/hm305/__init__.py
@@ -39,6 +39,50 @@ class HM305:
         Voltage_Max = 0xC11E  # returns 3200 = 32.0 V
         Current_Min = 0xC120  # returns 21 on my HM310P = 0.021A?
         Current_Max = 0xC12E  # returns 10100 on my HM310p = 10.1A
+        # M1 - M6 Memory key registers
+        # Factory defaults :-
+        #    Voltage: (1, 3, 5, 7, 9,10) / 10 * (UH =  3200) => (320,960,1600,2240,2880,3200)
+        #    Current: (1, 3, 5, 7, 9,10) / 10 * (UL = 10100) => (1010,3030,5050,7070,9090,10100)
+        #    Seconds: 10,11,12,13,14,15
+        #    Enable:   1, 1, 1, 1, 1, 1
+        Memory = {
+            "M1": {
+                "Voltage": 0x1000,  # (R/W)
+                "Current": 0x1001,  # (R/W)
+                "Time_span": 0x1002,  # (R/W)
+                "Enable": 0x1003,  # (R/W)
+            },
+            "M2": {
+                "Voltage": 0x1010,  # (R/W)
+                "Current": 0x1011,  # (R/W)
+                "Time_span": 0x1012,  # (R/W)
+                "Enable": 0x1013,  # (R/W)
+            },
+            "M3": {
+                "Voltage": 0x1020,  # (R/W)
+                "Current": 0x1021,  # (R/W)
+                "Time_span": 0x1022,  # (R/W)
+                "Enable": 0x1023,  # (R/W)
+            },
+            "M4": {
+                "Voltage": 0x1030,  # (R/W)
+                "Current": 0x1031,  # (R/W)
+                "Time_span": 0x1032,  # (R/W)
+                "Enable": 0x1033,  # (R/W)
+            },
+            "M5": {
+                "Voltage": 0x1040,  # (R/W)
+                "Current": 0x1041,  # (R/W)
+                "Time_span": 0x1042,  # (R/W)
+                "Enable": 0x1043,  # (R/W)
+            },
+            "M6": {
+                "Voltage": 0x1050,  # (R/W)
+                "Current": 0x1051,  # (R/W)
+                "Time_span": 0x1052,  # (R/W)
+                "Enable": 0x1053,  # (R/W)
+            },
+        }
 
     def __init__(self, fd=None):
         if fd is None:
@@ -149,6 +193,25 @@ class HM305:
     @property
     def device(self):
         return self._get_val(HM305.CMD.Device)
+
+    @property
+    def memory(self):
+        """ Return a dict of dicts for each [preset memory keys][registers] """
+        memory_values = {}
+        for key in HM305.CMD.Memory:
+            memory_values[key]["Voltage"] = self._get_val(
+                HM305.CMD.Memory[key]["Voltage"]
+            )
+            memory_values[key]["Current"] = self._get_val(
+                HM305.CMD.Memory[key]["Current"]
+            )
+            memory_values[key]["Time_span"] = self._get_val(
+                HM305.CMD.Memory[key]["Time_span"]
+            )
+            memory_values[key]["Enable"] = self._get_val(
+                HM305.CMD.Memory[key]["Enable"]
+            )
+        return memory_values
 
 
 def rint(x: float) -> int:

--- a/hm305/__init__.py
+++ b/hm305/__init__.py
@@ -2,8 +2,8 @@ import logging
 from enum import IntEnum
 import serial
 
-from hm305.floatsetting import FloatSetting
 from modbus import Modbus
+from hm305.floatsetting import FloatSetting
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +11,9 @@ logger = logging.getLogger(__name__)
 class HM305:
     class CMD(IntEnum):
         Output = 0x0001  # (R/W)
-        ProtectionStatus = 0x0002  # (R), bit field of "isOVP, isOCP, isOPP, isOTP, isSCP"
+        ProtectionStatus = (
+            0x0002  # (R), bit field of "isOVP, isOCP, isOPP, isOTP, isSCP"
+        )
         ModelNum = 0x0003  # (R)
         Class_detail = 0x0004  # (R) # returns "KP". Perhaps is ClassTemplate in DevicesClassInfo.xml?
         Decimals = 0x0005  # (R) # returns 0x233 == scale factors for V/A/P
@@ -25,7 +27,9 @@ class HM305:
         Set_Voltage = 0x0030
         Set_Current = 0x0031
         Set_Time_span = 0x0032
-        Power_state = 0x8801  # "device power on status address, 2 bytes / Device boot state"
+        Power_state = (
+            0x8801  # "device power on status address, 2 bytes / Device boot state"
+        )
         Default_show = 0x8802  # "default value display addr"
         SCP = 0x8803  # short-circuit protection
         Buzzer = 0x8804
@@ -39,14 +43,26 @@ class HM305:
     def __init__(self, fd=None):
         if fd is None:
             logger.debug("HM305 opened without a serial obj! using defaults.")
-            fd = serial.Serial('/dev/ttyUSB0', baudrate=9600, timeout=0.1)
+            fd = serial.Serial("/dev/ttyUSB0", baudrate=9600, timeout=0.1)
         self.modbus = Modbus(fd)
         # self.v_setpoint_sw = 0
         self.i_setpoint_sw = 0
-        self.voltage = FloatSetting(self.modbus, value_addr=HM305.CMD.Voltage, setpoint_addr=HM305.CMD.Set_Voltage,
-                                    value_scalar=100.0, min_addr=HM305.CMD.Voltage_Min, max_addr=HM305.CMD.Voltage_Max)
-        self.current = FloatSetting(self.modbus, value_addr=HM305.CMD.Current, setpoint_addr=HM305.CMD.Set_Current,
-                                    value_scalar=1000.0, min_addr=HM305.CMD.Current_Min, max_addr=HM305.CMD.Current_Max)
+        self.voltage = FloatSetting(
+            self.modbus,
+            value_addr=HM305.CMD.Voltage,
+            setpoint_addr=HM305.CMD.Set_Voltage,
+            value_scalar=100.0,
+            min_addr=HM305.CMD.Voltage_Min,
+            max_addr=HM305.CMD.Voltage_Max,
+        )
+        self.current = FloatSetting(
+            self.modbus,
+            value_addr=HM305.CMD.Current,
+            setpoint_addr=HM305.CMD.Set_Current,
+            value_scalar=1000.0,
+            min_addr=HM305.CMD.Current_Min,
+            max_addr=HM305.CMD.Current_Max,
+        )
 
     def _set_val(self, addr: int, val) -> bool:
         return self.modbus.set_by_addr(addr, val)
@@ -60,7 +76,7 @@ class HM305:
         else:
             a = self._set_val(addr, val >> 16)
             if a:
-                return self._set_val(addr + 1, val & 0xffff)
+                return self._set_val(addr + 1, val & 0xFFFF)
             return False
 
     def initialize(self):

--- a/hm305/command_factory.py
+++ b/hm305/command_factory.py
@@ -3,50 +3,68 @@ from functools import partial
 
 import scpi
 
-from hm305.server_commands import Command, MeasureVoltageQuery, VoltageSetpointQuery, VoltageApplyCommand, \
-    SetVoltageCommand, SetVoltageSetpointCommand, SetCurrentCommand, SetCurrentSetpointCommand, MeasureCurrentQuery, \
-    CurrentSetpointQuery, OutputQuery, SetOutputCommand, CurrentApplyCommand
+from hm305.server_commands import (
+    Command,
+    MeasureVoltageQuery,
+    VoltageSetpointQuery,
+    VoltageApplyCommand,
+    SetVoltageCommand,
+    SetVoltageSetpointCommand,
+    SetCurrentCommand,
+    SetCurrentSetpointCommand,
+    MeasureCurrentQuery,
+    CurrentSetpointQuery,
+    OutputQuery,
+    SetOutputCommand,
+    CurrentApplyCommand,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class CommandFactory:
-    Commands = scpi.Commands({
-        "VOLTage": partial(dict, get=MeasureVoltageQuery, set=SetVoltageCommand),
-        "VOLTage:SETPoint": partial(dict, get=VoltageSetpointQuery, set=SetVoltageSetpointCommand),
-        "VOLTage:APPLY": partial(dict, get=None, set=VoltageApplyCommand),
-        "CURRent": partial(dict, get=MeasureCurrentQuery, set=SetCurrentCommand),
-        "CURRent:SETPoint": partial(dict, get=CurrentSetpointQuery, set=SetCurrentSetpointCommand),
-        "CURRent:APPLY": partial(dict, get=None, set=CurrentApplyCommand),
-        "OUTput": partial(dict, get=OutputQuery, set=SetOutputCommand),
-    })
+    Commands = scpi.Commands(
+        {
+            "VOLTage": partial(dict, get=MeasureVoltageQuery, set=SetVoltageCommand),
+            "VOLTage:SETPoint": partial(
+                dict, get=VoltageSetpointQuery, set=SetVoltageSetpointCommand
+            ),
+            "VOLTage:APPLY": partial(dict, get=None, set=VoltageApplyCommand),
+            "CURRent": partial(dict, get=MeasureCurrentQuery, set=SetCurrentCommand),
+            "CURRent:SETPoint": partial(
+                dict, get=CurrentSetpointQuery, set=SetCurrentSetpointCommand
+            ),
+            "CURRent:APPLY": partial(dict, get=None, set=CurrentApplyCommand),
+            "OUTput": partial(dict, get=OutputQuery, set=SetOutputCommand),
+        }
+    )
 
     @staticmethod
     def parse(cmd_str: str) -> Command:
         cmd_str = cmd_str.strip()  # remove whitespace
-        is_query = cmd_str.endswith('?')
-        cmd_str = cmd_str.strip('? ')
-        while '  ' in cmd_str:
-            cmd_str = cmd_str.replace('  ', ' ')
+        is_query = cmd_str.endswith("?")
+        cmd_str = cmd_str.strip("? ")
+        while "  " in cmd_str:
+            cmd_str = cmd_str.replace("  ", " ")
             logger.debug(f"fixing cmd_str: {cmd_str}")
-        num_spaces = cmd_str.count(' ')
+        num_spaces = cmd_str.count(" ")
         to_return = None
         if num_spaces == 1:  # has arg
-            (cmd_str_base, arg_str) = cmd_str.split(' ')
+            (cmd_str_base, arg_str) = cmd_str.split(" ")
             scpi_cmd = CommandFactory.Commands[cmd_str_base]()
             if scpi_cmd is not None:
-                if is_query and scpi_cmd['get'] is not None:
-                    to_return = scpi_cmd['get'](arg_str)  # does this case exist?
-                elif not is_query and scpi_cmd['set'] is not None:
-                    to_return = scpi_cmd['set'](arg_str)
+                if is_query and scpi_cmd["get"] is not None:
+                    to_return = scpi_cmd["get"](arg_str)  # does this case exist?
+                elif not is_query and scpi_cmd["set"] is not None:
+                    to_return = scpi_cmd["set"](arg_str)
             else:
                 to_return = None
         elif num_spaces == 0:  # no arg
             scpi_cmd = CommandFactory.Commands[cmd_str]()
             if scpi_cmd is not None:
-                if is_query and scpi_cmd['get'] is not None:
-                    to_return = scpi_cmd['get']()
-                elif not is_query and scpi_cmd['set'] is not None:
+                if is_query and scpi_cmd["get"] is not None:
+                    to_return = scpi_cmd["get"]()
+                elif not is_query and scpi_cmd["set"] is not None:
                     to_return = None  # scpi_cmd['set']()  # does this case exist? I don't think so
             else:
                 to_return = None

--- a/hm305/floatsetting.py
+++ b/hm305/floatsetting.py
@@ -2,9 +2,17 @@ from modbus import Modbus
 
 
 class FloatSetting:
-    def __init__(self, modbus: Modbus, value_addr: int, setpoint_addr: int, value_scalar=1.0,
-                 minimum=0.0, min_addr=None,
-                 maximum=999.0, max_addr=None, ):
+    def __init__(
+        self,
+        modbus: Modbus,
+        value_addr: int,
+        setpoint_addr: int,
+        value_scalar=1.0,
+        minimum=0.0,
+        min_addr=None,
+        maximum=999.0,
+        max_addr=None,
+    ):
         self._modbus = modbus
         self._value_address = value_addr
         self._value_scalar = value_scalar

--- a/hm305/queue_handler.py
+++ b/hm305/queue_handler.py
@@ -44,7 +44,9 @@ class HM305pFastQueueHandler:
                 if item.stale:
                     logger.debug(f"stale item! {item}")
                 elif item.uses_serial_port:
-                    logger.error(f"Bad programmer! You cannot put {item} in the fast queue!")
+                    logger.error(
+                        f"Bad programmer! You cannot put {item} in the fast queue!"
+                    )
                     item.result = "QUEUE ERROR"
                 else:
                     logger.debug(f"processing {item}")

--- a/hm305/server.py
+++ b/hm305/server.py
@@ -3,8 +3,15 @@ import socketserver
 from typing import Any
 
 from hm305.command_factory import CommandFactory
-from hm305.server_commands import SetVoltageCommand, SetVoltageSetpointCommand, VoltageApplyCommand, \
-    Command, SetCurrentCommand, SetCurrentSetpointCommand, CurrentApplyCommand
+from hm305.server_commands import (
+    SetVoltageCommand,
+    SetVoltageSetpointCommand,
+    VoltageApplyCommand,
+    Command,
+    SetCurrentCommand,
+    SetCurrentSetpointCommand,
+    CurrentApplyCommand,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -22,11 +29,13 @@ class HM305pServer(socketserver.StreamRequestHandler):
     fast_q = None
     command_factory = CommandFactory()
 
-    def __init__(self, request: Any, client_address: Any, base_server: socketserver.BaseServer):
+    def __init__(
+        self, request: Any, client_address: Any, base_server: socketserver.BaseServer
+    ):
         super().__init__(request, client_address, base_server)
 
     def handle(self):
-        resp = ''
+        resp = ""
         msg = self.rfile.readline().strip().decode()
         logger.debug(f"REQ[{self.client_address[0]}]: {msg}")
         item = self.command_factory.parse(msg)
@@ -62,8 +71,8 @@ class HM305pServer(socketserver.StreamRequestHandler):
                 resp = item.result_as_string()
                 logger.debug(f"{item}")
             else:
-                resp = 'DONE\n'
+                resp = "DONE\n"
 
         else:
-            resp = 'error: cmd not found'
+            resp = "error: cmd not found"
         self.wfile.write(resp.encode())

--- a/hm305/server_commands.py
+++ b/hm305/server_commands.py
@@ -21,7 +21,7 @@ class Command:
         Sets result (if applicable) and complete before returning.
         The external command runner checks the stale flag first, not this function
         """
-        self.result = 'Not implemented'
+        self.result = "Not implemented"
         self.complete = True
 
     def result_as_string(self):
@@ -48,7 +48,7 @@ class CommandWithFloatArg(CommandWithArg):
         except ValueError as e:
             self.stale = True
             logger.error(e)
-            self.result = 'error: bad float'
+            self.result = "error: bad float"
 
     def result_as_string(self):
         return f"{self.result:2.3f}"
@@ -106,6 +106,7 @@ class SetVoltageCommand(CommandWithFloatArg):
     NOTE: This class is manually split into a SetVoltageSetpoint and a VoltageApply
     Need to find a cleaner way to do this
     """
+
     uses_serial_port = True
 
     def invoke(self, hm):
@@ -205,5 +206,3 @@ class CurrentSetpointQuery(QueryCommand):
     def invoke(self, hm):
         self.result = float(hm.current.setpoint)
         self.complete = True
-
-


### PR DESCRIPTION
This PR adds some support for query of the registers for the M1-M6 memory preset keys https://github.com/mckenm/HanmaTekPSUCmd/wiki/Registers.

I define them in a dict structure, the keys of which are then walked and the values retrieved if the `--get-memory` argument is passed.

eg.
```
$ python3 hm305.py --port /dev/tty.wchusbserial2210 --get-memory
2021-06-06 16:00:06,607 Memory Key Presets:
2021-06-06 16:00:06,607 M1 : 1.8 Volts
2021-06-06 16:00:06,608 M1 : 0.51 Amps
2021-06-06 16:00:06,608 M1 : 10 Time Span
2021-06-06 16:00:06,609 M1 : 1 Enabled
2021-06-06 16:00:06,609 M2 : 5.0 Volts
2021-06-06 16:00:06,609 M2 : 2.2 Amps
2021-06-06 16:00:06,610 M2 : 10 Time Span
2021-06-06 16:00:06,610 M2 : 1 Enabled
2021-06-06 16:00:06,610 M3 : 12.0 Volts
2021-06-06 16:00:06,610 M3 : 2.244 Amps
2021-06-06 16:00:06,610 M3 : 12 Time Span
2021-06-06 16:00:06,610 M3 : 1 Enabled
2021-06-06 16:00:06,610 M4 : 19.52 Volts
2021-06-06 16:00:06,610 M4 : 3.111 Amps
2021-06-06 16:00:06,610 M4 : 13 Time Span
2021-06-06 16:00:06,610 M4 : 1 Enabled
2021-06-06 16:00:06,611 M5 : 20.0 Volts
2021-06-06 16:00:06,611 M5 : 3.2 Amps
2021-06-06 16:00:06,611 M5 : 14 Time Span
2021-06-06 16:00:06,611 M5 : 1 Enabled
2021-06-06 16:00:06,611 M6 : 30.4 Volts
2021-06-06 16:00:06,611 M6 : 4.845 Amps
2021-06-06 16:00:06,611 M6 : 15 Time Span
2021-06-06 16:00:06,611 M6 : 1 Enabled
```